### PR TITLE
Bypass CSRF

### DIFF
--- a/PayMaya/Checkout/Controller/Checkout/ReturnAction.php
+++ b/PayMaya/Checkout/Controller/Checkout/ReturnAction.php
@@ -20,6 +20,9 @@ class ReturnAction extends \Magento\Framework\App\Action\Action
         parent::__construct($context);
         $this->configPayment = $configPayment;
         $this->resultJsonFactory = $resultJsonFactory;
+        
+        // Bypass CSRF
+        $this->getRequest()->setParam('ajax', true)->setParam('isAjax', true);
     }
 
     public function execute()


### PR DESCRIPTION
The paymaya callback was redirected to 404 page because of no form_key submitted from Paymaya server. This commit fixed the issue by skip CSRF check.